### PR TITLE
Change the locale for jsx-sort-props to en

### DIFF
--- a/react.js
+++ b/react.js
@@ -59,6 +59,7 @@ module.exports = {
     'react/jsx-sort-props': [
       ERROR,
       {
+        locale: 'en',
         ignoreCase: true,
         reservedFirst: ['key', 'ref']
       }


### PR DESCRIPTION
Sorting shall work the same for everybody, even when international team members use different locales.

See https://github.com/jsx-eslint/eslint-plugin-react/issues/3613